### PR TITLE
Added CatalogRelation as a match to PrivilegesBuilder

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/PrivilegesBuilder.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/PrivilegesBuilder.scala
@@ -112,6 +112,9 @@ private[sql] object PrivilegesBuilder {
 
       case m if m.nodeName == "MetastoreRelation" =>
         mergeProjection(getFieldVal(m, "catalogTable").asInstanceOf[CatalogTable])
+      
+      case c if c.nodeName == "CatalogRelation" =>
+      mergeProjection(getFieldVal(c, "tableMeta").asInstanceOf[CatalogTable])
 
       case l: LogicalRelation if l.catalogTable.nonEmpty => mergeProjection(l.catalogTable.get)
 

--- a/src/main/scala/org/apache/spark/sql/hive/PrivilegesBuilder.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/PrivilegesBuilder.scala
@@ -114,7 +114,7 @@ private[sql] object PrivilegesBuilder {
         mergeProjection(getFieldVal(m, "catalogTable").asInstanceOf[CatalogTable])
       
       case c if c.nodeName == "CatalogRelation" =>
-      mergeProjection(getFieldVal(c, "tableMeta").asInstanceOf[CatalogTable])
+        mergeProjection(getFieldVal(c, "tableMeta").asInstanceOf[CatalogTable])
 
       case l: LogicalRelation if l.catalogTable.nonEmpty => mergeProjection(l.catalogTable.get)
 


### PR DESCRIPTION
In spark2.2.0 hive2.2.0, certain clusters have issues where authorization fails because the request to Privileges Builder goes as CatalogRelation and not as LogicalRelation. Hence added the CatalogRelation in the match:case of the same. The changes were tested on the following cluster setup.

Spark : Spark Version 2.2.0 scala-2.11.8
Hive : Hive 2.2.0
Ranger Admin: 0.7.1
Ranger Plugin in spark/jars: 0.5.3
Spark-Authorizer: branch = master, build command: mvn package -Pspark-2.2