### PR TITLE
get view information when build privileges input

### DIFF
--- a/src/main/scala/org/apache/spark/sql/hive/PrivilegesBuilder.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/PrivilegesBuilder.scala
@@ -20,10 +20,8 @@ package org.apache.spark.sql.hive
 import java.util.{ArrayList => JAList, List => JList}
 
 import scala.collection.JavaConverters._
-
 import org.apache.hadoop.hive.ql.security.authorization.plugin.{HivePrivilegeObject => HPO}
-import org.apache.hadoop.hive.ql.security.authorization.plugin.HivePrivilegeObject.{HivePrivilegeObjectType, HivePrivObjectActionType}
-
+import org.apache.hadoop.hive.ql.security.authorization.plugin.HivePrivilegeObject.{HivePrivObjectActionType, HivePrivilegeObjectType}
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
@@ -105,6 +103,8 @@ private[sql] object PrivilegesBuilder {
     }
 
     plan match {
+      case p: View => mergeProjection(getFieldVal(p, "desc").asInstanceOf[CatalogTable])
+
       case p: Project => buildQuery(p.child, hivePrivilegeObjects, p.projectList)
 
       case h if h.nodeName == "HiveTableRelation" =>


### PR DESCRIPTION
Both spark and spark-authorizer need to be modified.

1, in spark，before apply rule “EliminateView”，we need store the view information

2, in spark-authorizer, we can get the view information when build privileges